### PR TITLE
chore!: update taffybar, resolver, CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Install system dependencies
         run: >
+          sudo apt-get update
           sudo apt-get install libgirepository1.0-dev libwebkit2gtk-4.0-dev libgtksourceview-3.0-dev
           libdbusmenu-gtk3-dev libxss-dev
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup GHC with Stack
         uses: haskell/actions/setup@v2
         with:
-          ghc-version: "9.0.2"
+          ghc-version: "9.2.5"
           enable-stack: true
 
       - name: Cache ~/.stack

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,10 +45,9 @@ jobs:
           restore-keys: ${{ runner.os }}-stack-work-
 
       - name: Install system dependencies
-        run: >
+        run: |
           sudo apt-get update
-          sudo apt-get install libgirepository1.0-dev libwebkit2gtk-4.0-dev libgtksourceview-3.0-dev
-          libdbusmenu-gtk3-dev libxss-dev
+          sudo apt-get install libgirepository1.0-dev libwebkit2gtk-4.0-dev libgtksourceview-3.0-dev libdbusmenu-gtk3-dev libxss-dev
 
       - name: Install dependencies
         run: |

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,7 +21,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.4
+resolver: lts-20.6
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -50,7 +50,7 @@ packages:
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
 extra-deps:
-- rate-limit-1.4.2@sha256:78b935d96fe82b4d059908557e2c904925e99fcd465e2b4dfd65b8d2930163a2,930
+  - rate-limit-1.4.3
 # Override default flag values for local packages and extra-deps
 flags: {}
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,7 +21,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.1
+resolver: lts-20.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Updated taffybar to latest [master](https://github.com/taffybar/taffybar/commit/253c10fc2af08d3d9eab9ca2362f4dce05c58554)
Updated stack resolver to 20.6.
Updated CI ghc version to 9.2.5.
Changed CI build script to update `apt-get` database before installing system dependencies.